### PR TITLE
Update POGOProtos.Core dependency to version 2.58.5

### DIFF
--- a/PolygonStats/PolygonStats.csproj
+++ b/PolygonStats/PolygonStats.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="NetCoreServer" Version="7.0.0" />
-    <PackageReference Include="POGOProtos.Core" Version="2.57.7" />
+    <PackageReference Include="POGOProtos.Core" Version="2.58.5" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />
     <PackageReference Include="S2Geometry" Version="1.0.3" />
     <PackageReference Include="Serilog" Version="2.12.0" />

--- a/PolygonStats/PolygonStats.csproj
+++ b/PolygonStats/PolygonStats.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <PackageReference Include="Discord.Net.Webhook" Version="3.9.0" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Google.Protobuf" Version="3.21.12" />
+    <PackageReference Include="Google.Protobuf" Version="3.22.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.2" />


### PR DESCRIPTION
### Changes

This commit updates the `POGOProtos.Core` package from version 2.57.7 to 2.58.5. *`.csproj`*

### Concerns

Although I have yet to perform a comprehensive test on these changes, I will take some time later today. I will append the Docker configurations in a subsequent pull request. If immediate testing is a prerequisite, I am open to any assistance or suggestions. : )